### PR TITLE
Replaced ancestorRenderObjectOfType

### DIFF
--- a/lib/ui/sliver_search_bar.dart
+++ b/lib/ui/sliver_search_bar.dart
@@ -239,8 +239,7 @@ class _FloatingAppBarState extends State<_FloatingAppBar> {
   }
 
   RenderSliverFloatingPersistentHeader _headerRenderer() {
-    return context.ancestorRenderObjectOfType(
-        const TypeMatcher<RenderSliverFloatingPersistentHeader>());
+    return context.findAncestorRenderObjectOfType<RenderSliverFloatingPersistentHeader>();
   }
 
   void _isScrollingListener() {


### PR DESCRIPTION
Replaced depricated ancestorRenderObjectOfType with findAncestorRenderObjectOfType to fix the upgrade issue to flutter 2